### PR TITLE
feat: 도커 컨테이너에서 자바로 채점하기 기능을 구현

### DIFF
--- a/src/main/java/com/thinktank/api/controller/JudgeController.java
+++ b/src/main/java/com/thinktank/api/controller/JudgeController.java
@@ -1,0 +1,26 @@
+package com.thinktank.api.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.thinktank.api.dto.judge.request.JudgeDto;
+import com.thinktank.api.service.JudgeService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class JudgeController {
+	private final JudgeService judgeService;
+
+	@PostMapping("/judge")
+	public ResponseEntity<String> judge(@RequestBody JudgeDto dto) {
+		judgeService.judge(dto);
+
+		return ResponseEntity.ok("성공");
+	}
+}

--- a/src/main/java/com/thinktank/api/dto/judge/request/JudgeDto.java
+++ b/src/main/java/com/thinktank/api/dto/judge/request/JudgeDto.java
@@ -1,0 +1,20 @@
+package com.thinktank.api.dto.judge.request;
+
+import java.util.List;
+
+import com.thinktank.api.dto.testcase.custom.TestCaseDto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record JudgeDto(
+	@NotNull
+	Long postId,
+
+	@NotNull
+	List<TestCaseDto> testCases,
+
+	@NotBlank
+	String code
+) {
+}

--- a/src/main/java/com/thinktank/api/dto/testcase/custom/TestCaseDto.java
+++ b/src/main/java/com/thinktank/api/dto/testcase/custom/TestCaseDto.java
@@ -1,0 +1,12 @@
+package com.thinktank.api.dto.testcase.custom;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TestCaseDto(
+	@NotBlank
+	String example,
+
+	@NotBlank
+	String result
+) {
+}

--- a/src/main/java/com/thinktank/api/service/JudgeService.java
+++ b/src/main/java/com/thinktank/api/service/JudgeService.java
@@ -1,0 +1,24 @@
+package com.thinktank.api.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.thinktank.api.dto.judge.request.JudgeDto;
+import com.thinktank.api.repository.PostRepository;
+import com.thinktank.global.common.util.JavaJudge;
+import com.thinktank.global.common.util.JudgeUtil;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class JudgeService {
+	private final PostRepository postRepository;
+
+	public void judge(JudgeDto dto) {
+		final JudgeUtil judgeManager = new JavaJudge();
+
+		judgeManager.executeCode(dto.testCases(), dto.code());
+	}
+}

--- a/src/main/java/com/thinktank/global/common/util/GlobalConstant.java
+++ b/src/main/java/com/thinktank/global/common/util/GlobalConstant.java
@@ -1,0 +1,12 @@
+package com.thinktank.global.common.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class GlobalConstant {
+	public static final int EXECUTION_TIME_LIMIT = 3000;
+	public static final String FULL_CLASS_NAME = "Main";
+	public static final String STAND_CLASS_NAME = "Main.java";
+	public static final int ZERO = 0;
+}

--- a/src/main/java/com/thinktank/global/common/util/JavaJudge.java
+++ b/src/main/java/com/thinktank/global/common/util/JavaJudge.java
@@ -1,0 +1,154 @@
+package com.thinktank.global.common.util;
+
+import static com.thinktank.global.common.util.GlobalConstant.*;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import com.thinktank.api.dto.testcase.custom.TestCaseDto;
+import com.thinktank.global.error.exception.BadRequestException;
+import com.thinktank.global.error.model.ErrorCode;
+
+public class JavaJudge implements JudgeUtil {
+	@Override
+	public void executeCode(List<TestCaseDto> testCases, String code) {
+		final String uniqueDirName = UUID.randomUUID().toString();
+		final File directory = new File(uniqueDirName);
+
+		validateExist(directory);
+		try {
+			final File sourceFile = createFile(directory, code);
+
+			startCompile(sourceFile, testCases, directory);
+		} catch (IOException e) {
+			throw new BadRequestException(ErrorCode.BAD_REQUEST);
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new BadRequestException(ErrorCode.BAD_REQUEST_TIME_OUT);
+		} finally {
+			delete(directory);
+		}
+	}
+
+	private void startCompile(
+		File sourceFile,
+		List<TestCaseDto> testCases,
+		File tempDir
+	) throws InterruptedException, IOException {
+		final String tempDirPath = tempDir.getAbsolutePath();
+		final Process compileProcess = startDockerCompile(sourceFile, tempDirPath).start();
+
+		validateCompile(compileProcess);
+		runTestCases(testCases, tempDir);
+		Thread.currentThread().interrupt();
+	}
+
+	private void validateCompile(Process compileProcess) throws InterruptedException {
+		if (compileProcess.waitFor() != ZERO) {
+			throw new BadRequestException(ErrorCode.BAD_REQUEST_COMPILE_ERROR);
+		}
+	}
+
+	private void runTestCases(List<TestCaseDto> testCases, File tempDir) throws IOException {
+		final ProcessBuilder builder = startDockerRun(tempDir);
+
+		for (TestCaseDto testCase : testCases) {
+			final Process process = builder.start();
+			final BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(process.getOutputStream()));
+			final BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+
+			writer.write(testCase.example() + "\n");
+			writer.flush();
+
+			final long startTime = System.currentTimeMillis();
+
+			timeOutCheck(process, startTime);
+
+			final String output = reader.readLine();
+
+			validateJudge(testCase.result(), output);
+		}
+	}
+
+	private void timeOutCheck(Process process, long startTime) {
+		while (!isProcessCompleted(process)) {
+			if (System.currentTimeMillis() - startTime > EXECUTION_TIME_LIMIT) {
+				process.destroy();
+				throw new BadRequestException(ErrorCode.BAD_REQUEST_TIME_OUT);
+			}
+		}
+	}
+
+	private boolean isProcessCompleted(Process process) {
+		try {
+			process.exitValue();
+			return true;
+		} catch (IllegalThreadStateException e) {
+			return false;
+		}
+	}
+
+	private static void validateJudge(String testCase, String output) {
+		if (!output.equals(testCase)) {
+			throw new BadRequestException(ErrorCode.BAD_REQUEST_FAIL);
+		}
+	}
+
+	private ProcessBuilder startDockerCompile(File sourceFile, String tempDirPath) {
+		return new ProcessBuilder(
+			"docker", "run", "--rm",
+			"-v", tempDirPath + ":/usr/src/myapp",
+			"-w", "/usr/src/myapp",
+			"openjdk:17",
+			"javac", sourceFile.getName());
+	}
+
+	private ProcessBuilder startDockerRun(File tempDir) {
+		final List<String> command = Arrays.asList(
+			"docker", "run", "--rm", "-i",
+			"-v", tempDir.getAbsolutePath() + ":/app",
+			"openjdk:17",
+			"sh", "-c", "cd /app && java " + FULL_CLASS_NAME
+		);
+
+		return new ProcessBuilder(command).redirectErrorStream(true);
+	}
+
+	private File createFile(File tempDir, String code) {
+		final File sourceFile = new File(tempDir, STAND_CLASS_NAME);
+
+		try (BufferedWriter writer = new BufferedWriter(new FileWriter(sourceFile))) {
+			writer.write(code);
+		} catch (IOException e) {
+			throw new BadRequestException(ErrorCode.BAD_REQUEST);
+		}
+
+		return sourceFile;
+	}
+
+	private void validateExist(File tempDir) {
+		if (!tempDir.mkdirs()) {
+			throw new BadRequestException(ErrorCode.BAD_REQUEST);
+		}
+	}
+
+	private void delete(File directory) {
+		final File[] allContents = directory.listFiles();
+
+		if (allContents != null) {
+			for (File file : allContents) {
+				delete(file);
+			}
+		}
+
+		directory.delete();
+	}
+}

--- a/src/main/java/com/thinktank/global/common/util/JudgeUtil.java
+++ b/src/main/java/com/thinktank/global/common/util/JudgeUtil.java
@@ -1,0 +1,9 @@
+package com.thinktank.global.common.util;
+
+import java.util.List;
+
+import com.thinktank.api.dto.testcase.custom.TestCaseDto;
+
+public interface JudgeUtil {
+	void executeCode(List<TestCaseDto> testCases, String code);
+}

--- a/src/main/java/com/thinktank/global/error/model/ErrorCode.java
+++ b/src/main/java/com/thinktank/global/error/model/ErrorCode.java
@@ -13,6 +13,10 @@ public enum ErrorCode {
 	FAIL_WRONG_PASSWORD("[❎ ERROR] 비밀번호가 일치하지 않습니다."),
 	FAIL_INVALID_CATEGORY("[❎ ERROR] 유효하지 않은 카테고리입니다."),
 	FAIL_INVALID_LANGUAGE("[❎ ERROR] 유효하지 않은 카테고리입니다."),
+	BAD_REQUEST_COMPILE_ERROR("[❎실패] 컴파일 에러 입니다."),
+	BAD_REQUEST_RUNTIME_ERROR("[❎실패] 런타임 에러 입니다."),
+	BAD_REQUEST_FAIL("[❎실패] 테스트케이스를 통과하지 못했습니다."),
+	BAD_REQUEST_TIME_OUT("[❎실패] 시간 초과입니다."),
 
 	// 401
 	FAIL_UNAUTHORIZED_EXCEPTION("[❎ ERROR] 로그인이 필요한 기능입니다."),


### PR DESCRIPTION
## 📋 Checklist

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. `feat: 유저 조회 기능 구현`)
- [x] 🏷️ 라벨, 프로젝트는 등록했나요?
- [x] 🧹 코드 스멜은 해결했나요?

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #11 

## 👩‍💻 공유 포인트 및 논의 사항
* 언어의 확장성을 고려하여 JudgeUtil 인터페이스를 생성해 주었습니다.
* 현재 각 테스트케이스별 컨테이너를 생성 후 삭제하는데, 성능을 비교해보며 추후 리팩터링 하겠습니다.
* TestCaseDto는 API 명세에 따른 테스트케이스를 받는 형식입니다.
* 컨트롤러에서 Validation 처리가 없고, JudgeDto에 메시지가 현재 없는데, 아직 저장된 테스트케이스들이 없으므로, 추후 Code, UserCode 엔티티를 추가하고 리팩터링 하겠습니다.
* 서비스에서 PostRepositoty를 주입받고 사용하는 부분이 없습니다. 이 또한 아직 저장된 테스트케이스들이 없으므로 위와 같이 추후 리팩터링 하겠습니다.
* JudgeDto에 현재 언어를 받는 부분이 없습니다. 추후 자바스크립트 채점기능을 구현하면서 String Language를 추가하고 서비스에서 judge 메서드에서 언어별 주입 받는 방식을 바꾸는 걸로 리팩터링 하겠습니다.
* JudgeUtil에서 excuteCode 메서드의 매개변수가 커스텀 테스트케이스 dto와, 코드로 구현한 이유는, 저의 경우 dto만 전달하면 되지만 
* 지수님은 게시글을 생성할 때 dto 전체가 아닌, dto에 담긴 테스트케이스, 코드를 넣어줘야 되기 때문입니다.
