### PR TITLE
feat: 로그아웃 기능 구현

### DIFF
--- a/src/main/java/com/thinktank/api/controller/UserController.java
+++ b/src/main/java/com/thinktank/api/controller/UserController.java
@@ -14,6 +14,8 @@ import com.thinktank.api.dto.user.request.SignUpDto;
 import com.thinktank.api.dto.user.response.LoginResDto;
 import com.thinktank.api.service.UserService;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -32,7 +34,15 @@ public class UserController {
 
 	@PostMapping("/login")
 	@ResponseStatus(HttpStatus.OK)
-	public ResponseEntity<LoginResDto> login(@RequestBody @Validated LoginReqDto loginReqDto) {
-		return ResponseEntity.ok(userService.login(loginReqDto));
+	public ResponseEntity<LoginResDto> login(
+		@RequestBody @Validated LoginReqDto loginReqDto, HttpServletResponse response
+	) {
+		return ResponseEntity.ok(userService.login(loginReqDto, response));
+	}
+
+	@PostMapping("/logout")
+	public ResponseEntity<String> logout(HttpServletRequest request, HttpServletResponse response) {
+		userService.logout(request, response);
+		return ResponseEntity.ok("OK");
 	}
 }

--- a/src/main/java/com/thinktank/api/entity/UserCode.java
+++ b/src/main/java/com/thinktank/api/entity/UserCode.java
@@ -16,7 +16,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "tbl_user")
+@Table(name = "tbl_user_code")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserCode {
 	@Id

--- a/src/main/java/com/thinktank/api/service/UserService.java
+++ b/src/main/java/com/thinktank/api/service/UserService.java
@@ -1,5 +1,7 @@
 package com.thinktank.api.service;
 
+import static com.thinktank.global.common.util.AuthConstants.*;
+
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -8,14 +10,21 @@ import com.thinktank.api.dto.user.request.LoginReqDto;
 import com.thinktank.api.dto.user.request.SignUpDto;
 import com.thinktank.api.dto.user.response.LoginResDto;
 import com.thinktank.api.entity.User;
+import com.thinktank.api.entity.auth.AuthUser;
 import com.thinktank.api.repository.UserRepository;
 import com.thinktank.api.service.auth.JwtProviderService;
+import com.thinktank.global.common.util.CookieUtils;
 import com.thinktank.global.error.exception.BadRequestException;
 import com.thinktank.global.error.exception.NotFoundException;
 import com.thinktank.global.error.model.ErrorCode;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -38,7 +47,7 @@ public class UserService {
 	}
 
 	@Transactional
-	public LoginResDto login(LoginReqDto loginReqDto) {
+	public LoginResDto login(LoginReqDto loginReqDto, HttpServletResponse response) {
 		final User user = userRepository.findByEmail(loginReqDto.email())
 			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_NOT_USER_FOUND_EXCEPTION));
 
@@ -48,7 +57,29 @@ public class UserService {
 		final String refreshToken = jwtProviderService.generateRefreshToken(user.getEmail());
 		user.updateRefreshToken(refreshToken);
 
+		response.setHeader(ACCESS_TOKEN_HEADER, accessToken);
+
+		Cookie refreshTokenCookie = CookieUtils.generateRefreshTokenCookie(REFRESH_TOKEN_COOKIE_NAME, refreshToken);
+		response.addCookie(refreshTokenCookie);
+
 		return new LoginResDto(accessToken, refreshToken);
+	}
+
+	@Transactional
+	public void logout(HttpServletRequest request, HttpServletResponse response) {
+		String refreshToken = jwtProviderService.extractRefreshToken(REFRESH_TOKEN_COOKIE_NAME, request);
+
+		AuthUser authUser = jwtProviderService.extractAuthUserByAccessToken(refreshToken);
+		if (authUser != null) {
+			final User user = userRepository.findByEmail(authUser.email())
+				.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_NOT_USER_FOUND_EXCEPTION));
+
+			user.updateRefreshToken(null);
+		}
+
+		Cookie refreshTokenCookie = CookieUtils.expireRefreshTokenCookie(REFRESH_TOKEN_COOKIE_NAME);
+
+		response.addCookie(refreshTokenCookie);
 	}
 
 	private void validateEmailNotExists(String email) {

--- a/src/main/java/com/thinktank/global/common/util/AuthConstants.java
+++ b/src/main/java/com/thinktank/global/common/util/AuthConstants.java
@@ -7,6 +7,6 @@ import lombok.NoArgsConstructor;
 public final class AuthConstants {
 
 	public static final String ACCESS_TOKEN_HEADER = "access";
-	public static final String REFRESH_TOKEN_HEADER = "refresh";
+	public static final String REFRESH_TOKEN_COOKIE_NAME = "refresh";
 	public static final String BEARER = "Bearer";
 }

--- a/src/main/java/com/thinktank/global/common/util/CookieUtils.java
+++ b/src/main/java/com/thinktank/global/common/util/CookieUtils.java
@@ -1,0 +1,39 @@
+package com.thinktank.global.common.util;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+
+public class CookieUtils {
+
+	private static final int COOKIE_MAX_AGE = 24 * 60 * 60;
+
+	public static Cookie generateRefreshTokenCookie(String refreshTokenName, String token) {
+		Cookie refreshTokenCookie = new Cookie(refreshTokenName, token);
+		refreshTokenCookie.setMaxAge(COOKIE_MAX_AGE);
+		refreshTokenCookie.setHttpOnly(true);
+
+		return refreshTokenCookie;
+	}
+
+	public static String getCookieValue(String cookieName, HttpServletRequest request) {
+		Cookie[] cookies = Optional.ofNullable(request.getCookies())
+			.orElse(new Cookie[0]);
+
+		return Arrays.stream(cookies)
+			.filter(cookie -> cookie.getName().equals(cookieName))
+			.findFirst()
+			.map(Cookie::getValue)
+			.orElse(null);
+	}
+
+	public static Cookie expireRefreshTokenCookie(String refreshTokenName) {
+		Cookie refreshTokenCookie = new Cookie(refreshTokenName, null);
+		refreshTokenCookie.setHttpOnly(true);
+		refreshTokenCookie.setMaxAge(0);
+
+		return refreshTokenCookie;
+	}
+}

--- a/src/main/java/com/thinktank/global/common/util/GlobalConstant.java
+++ b/src/main/java/com/thinktank/global/common/util/GlobalConstant.java
@@ -9,4 +9,5 @@ public class GlobalConstant {
 	public static final String FULL_CLASS_NAME = "Main";
 	public static final String STAND_CLASS_NAME = "Main.java";
 	public static final int ZERO = 0;
+	public static final String BLANK = " ";
 }

--- a/src/main/java/com/thinktank/global/config/SecurityConfig.java
+++ b/src/main/java/com/thinktank/global/config/SecurityConfig.java
@@ -42,7 +42,8 @@ public class SecurityConfig {
 			.requestMatchers(PathRequest.toStaticResources().atCommonLocations())
 			.requestMatchers("/h2-console/**")
 			.requestMatchers("/api/signup")
-			.requestMatchers("/api/login");
+			.requestMatchers("/api/login")
+			.requestMatchers("/api/logout");
 	}
 
 	@Bean
@@ -59,7 +60,7 @@ public class SecurityConfig {
 			.sessionManagement(session -> session.sessionCreationPolicy(STATELESS));
 
 		httpSecurity.authorizeHttpRequests((auth) -> auth
-			.requestMatchers("/api/login", "/api/signup").permitAll()
+			.requestMatchers("/api/login", "/api/logout", "/api/signup").permitAll()
 			.anyRequest().authenticated()
 		);
 

--- a/src/main/java/com/thinktank/global/error/model/ErrorCode.java
+++ b/src/main/java/com/thinktank/global/error/model/ErrorCode.java
@@ -13,24 +13,24 @@ public enum ErrorCode {
 	FAIL_WRONG_PASSWORD("[❎ ERROR] 비밀번호가 일치하지 않습니다."),
 	FAIL_INVALID_CATEGORY("[❎ ERROR] 유효하지 않은 카테고리입니다."),
 	FAIL_INVALID_LANGUAGE("[❎ ERROR] 유효하지 않은 카테고리입니다."),
+	BAD_REQUEST_COMPILE_ERROR("[❎실패] 컴파일 에러 입니다."),
+	BAD_REQUEST_RUNTIME_ERROR("[❎실패] 런타임 에러 입니다."),
+	BAD_REQUEST_FAIL("[❎실패] 테스트케이스를 통과하지 못했습니다."),
+	BAD_REQUEST_TIME_OUT("[❎실패] 시간 초과입니다."),
 
 	// 401
 	FAIL_UNAUTHORIZED_EXCEPTION("[❎ ERROR] 로그인이 필요한 기능입니다."),
-
 	//403
 	POST_POST_FORBIDDEN_EXCEPTION("[❎ ERROR] 게시글 작성 권한이 없습니다."),
 	DELETE_POST_FORBIDDEN_EXCEPTION("[❎ ERROR] 게시글 삭제 권한이 없습니다."),
 	POST_COMMENT_FORBIDDEN_EXCEPTION("[❎ ERROR] 댓글 작성 권한이 없습니다."),
 	DELETE_COMMENT_FORBIDDEN_EXCEPTION("[❎ ERROR] 댓글 삭제 권한이 없습니다."),
-
 	// 404
 	FAIL_NOT_POST_FOUND_EXCEPTION("[❎ ERROR] 요청하신 게시물을 찾을 수 없습니다."),
 	FAIL_NOT_USER_FOUND_EXCEPTION("[❎ ERROR] 요청하신 회원을 찾을 수 없습니다."),
 	FAIL_NOT_COMMENT_FOUND_EXCEPTION("[❎ ERROR] 요청하신 댓글을 찾을 수 없습니다."),
-
 	// 409
 	FAIL_EMAIL_CONFLICT("[❎ ERROR] 이미 존재하는 이메일입니다."),
 	FAIL_NICKNAME_CONFLICT("[❎ ERROR] 이미 존재하는 닉네임입니다.");
-
 	private String message;
 }

--- a/src/main/java/com/thinktank/global/error/model/ErrorCode.java
+++ b/src/main/java/com/thinktank/global/error/model/ErrorCode.java
@@ -8,7 +8,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public enum ErrorCode {
-	// 400
+
+	// 400: BAD REQUEST
 	BAD_REQUEST("[❎ ERROR]"),
 	FAIL_WRONG_PASSWORD("[❎ ERROR] 비밀번호가 일치하지 않습니다."),
 	FAIL_INVALID_CATEGORY("[❎ ERROR] 유효하지 않은 카테고리입니다."),
@@ -18,21 +19,25 @@ public enum ErrorCode {
 	BAD_REQUEST_FAIL("[❎실패] 테스트케이스를 통과하지 못했습니다."),
 	BAD_REQUEST_TIME_OUT("[❎실패] 시간 초과입니다."),
 
-	// 401
+	// 401: UNAUTHORIZED
 	FAIL_UNAUTHORIZED_EXCEPTION("[❎ ERROR] 로그인이 필요한 기능입니다."),
+	FAIL_TOKEN_EXPIRED_EXCEPTION("[❎ ERROR] 인증 토큰이 만료되었습니다."),
+	FAIL_INVALID_TOKEN_EXCEPTION("[❎ ERROR] 유효하지 않은 인증 토큰입니다."),
 
-	//403
+	// 403: FORBIDDEN
 	POST_POST_FORBIDDEN_EXCEPTION("[❎ ERROR] 게시글 작성 권한이 없습니다."),
 	DELETE_POST_FORBIDDEN_EXCEPTION("[❎ ERROR] 게시글 삭제 권한이 없습니다."),
 	POST_COMMENT_FORBIDDEN_EXCEPTION("[❎ ERROR] 댓글 작성 권한이 없습니다."),
 	DELETE_COMMENT_FORBIDDEN_EXCEPTION("[❎ ERROR] 댓글 삭제 권한이 없습니다."),
 
-	// 404
+	// 404: NOT FOUNT
 	FAIL_NOT_POST_FOUND_EXCEPTION("[❎ ERROR] 요청하신 게시물을 찾을 수 없습니다."),
 	FAIL_NOT_USER_FOUND_EXCEPTION("[❎ ERROR] 요청하신 회원을 찾을 수 없습니다."),
 	FAIL_NOT_COMMENT_FOUND_EXCEPTION("[❎ ERROR] 요청하신 댓글을 찾을 수 없습니다."),
+	FAIL_NOT_TOKEN_FOUND_EXCEPTION("[❎ ERROR] 요청하신 토큰을 찾을 수 없습니다."),
+	FAIL_NOT_COOKIE_FOUND_EXCEPTION("[❎ ERROR] 요청하신 쿠키를 찾을 수 없습니다."),
 
-	// 409
+	// 409: CONFLICT
 	FAIL_EMAIL_CONFLICT("[❎ ERROR] 이미 존재하는 이메일입니다."),
 	FAIL_NICKNAME_CONFLICT("[❎ ERROR] 이미 존재하는 닉네임입니다.");
 


### PR DESCRIPTION
## 📋 Checklist

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. `feat: 유저 조회 기능 구현`)
- [x] 🏷️ 라벨, 프로젝트는 등록했나요?
- [x] 🧹 코드 스멜은 해결했나요?

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #26 

## 👩‍💻 공유 포인트 및 논의 사항
- 액세스 토큰은 헤더에, 리프레쉬 토큰은 쿠키에 저장되도록 했습니다.
- 로그아웃 시 DB와 쿠키에서 리프레쉬 토큰이 제거되도록 했습니다.
- UserCode 테이블명이 **tbl_user**로 되어 있어서 **tbl_user_code**로 수정했습니다.