### PR TITLE
feat: 회원 정보 조회 기능 구현

### DIFF
--- a/src/main/java/com/thinktank/api/controller/UserController.java
+++ b/src/main/java/com/thinktank/api/controller/UserController.java
@@ -3,6 +3,7 @@ package com.thinktank.api.controller;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,7 +13,10 @@ import org.springframework.web.bind.annotation.RestController;
 import com.thinktank.api.dto.user.request.LoginReqDto;
 import com.thinktank.api.dto.user.request.SignUpDto;
 import com.thinktank.api.dto.user.response.LoginResDto;
+import com.thinktank.api.dto.user.response.UserResDto;
+import com.thinktank.api.entity.auth.AuthUser;
 import com.thinktank.api.service.UserService;
+import com.thinktank.global.auth.annotation.Auth;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -44,5 +48,10 @@ public class UserController {
 	public ResponseEntity<String> logout(HttpServletRequest request, HttpServletResponse response) {
 		userService.logout(request, response);
 		return ResponseEntity.ok("OK");
+	}
+
+	@GetMapping("/users")
+	public ResponseEntity<UserResDto> findUserDetails(@Auth AuthUser authUser) {
+		return ResponseEntity.ok(userService.findUserDetails(authUser));
 	}
 }

--- a/src/main/java/com/thinktank/api/dto/user/response/UserResDto.java
+++ b/src/main/java/com/thinktank/api/dto/user/response/UserResDto.java
@@ -1,0 +1,10 @@
+package com.thinktank.api.dto.user.response;
+
+public record UserResDto(
+	String email,
+	String nickname,
+	String github,
+	String blog,
+	String introduce
+) {
+}

--- a/src/main/java/com/thinktank/api/service/auth/JwtProviderService.java
+++ b/src/main/java/com/thinktank/api/service/auth/JwtProviderService.java
@@ -79,13 +79,15 @@ public class JwtProviderService {
 	public String extractAccessToken(String header, HttpServletRequest request) {
 		String token = request.getHeader(header);
 
-		if (token == null || !token.startsWith(BEARER)) {
-			log.warn("{} IS NULL OR NOT BEARER", header);
+		if (token == null) {
+			log.warn("{} IS NULL", header);
+			return null;
+		} else if (!token.startsWith(BEARER)) {
+			log.warn("{} IS NOT BEARER", header);
 			return null;
 		}
 
-		return token.replaceFirst(BEARER, "")
-			.trim();
+		return token.replaceFirst(BEARER, "").trim();
 	}
 
 	public String extractRefreshToken(String cookieName, HttpServletRequest request) {

--- a/src/main/java/com/thinktank/global/auth/AuthorizationThreadLocal.java
+++ b/src/main/java/com/thinktank/global/auth/AuthorizationThreadLocal.java
@@ -1,0 +1,28 @@
+package com.thinktank.global.auth;
+
+import com.thinktank.api.entity.auth.AuthUser;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class AuthorizationThreadLocal {
+
+	private static final ThreadLocal<AuthUser> authUser;
+
+	static {
+		authUser = new ThreadLocal<>();
+	}
+
+	public static void setAuthUser(AuthUser authUser) {
+		AuthorizationThreadLocal.authUser.set(authUser);
+	}
+
+	public static AuthUser getAuthUser() {
+		return authUser.get();
+	}
+
+	public static void remove() {
+		authUser.remove();
+	}
+}

--- a/src/main/java/com/thinktank/global/auth/annotation/Auth.java
+++ b/src/main/java/com/thinktank/global/auth/annotation/Auth.java
@@ -1,0 +1,15 @@
+package com.thinktank.global.auth.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : authUser")
+public @interface Auth {
+
+}

--- a/src/main/java/com/thinktank/global/auth/handler/AuthUserArgumentResolver.java
+++ b/src/main/java/com/thinktank/global/auth/handler/AuthUserArgumentResolver.java
@@ -1,0 +1,31 @@
+package com.thinktank.global.auth.handler;
+
+import static com.thinktank.global.auth.AuthorizationThreadLocal.*;
+
+import java.util.Objects;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import com.thinktank.api.entity.auth.AuthUser;
+import com.thinktank.global.auth.annotation.Auth;
+
+import jakarta.annotation.Nullable;
+
+public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return Objects.nonNull(parameter.getParameterAnnotation(Auth.class))
+			&& parameter.getParameterType().equals(AuthUser.class);
+	}
+
+	@Override
+	public Object resolveArgument(@Nullable MethodParameter parameter, ModelAndViewContainer mavContainer,
+		@Nullable NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+		return getAuthUser();
+	}
+}

--- a/src/main/java/com/thinktank/global/config/SecurityConfig.java
+++ b/src/main/java/com/thinktank/global/config/SecurityConfig.java
@@ -19,7 +19,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.web.servlet.HandlerExceptionResolver;
 
 import com.thinktank.api.service.auth.JwtProviderService;
-import com.thinktank.global.auth.filter.AuthorizationFilter;
+import com.thinktank.global.auth.filter.AuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -65,7 +65,7 @@ public class SecurityConfig {
 		);
 
 		httpSecurity.addFilterBefore(
-			new AuthorizationFilter(jwtProviderService, handlerExceptionResolver),
+			new AuthenticationFilter(jwtProviderService, handlerExceptionResolver),
 			UsernamePasswordAuthenticationFilter.class
 		);
 

--- a/src/main/java/com/thinktank/global/config/WebConfig.java
+++ b/src/main/java/com/thinktank/global/config/WebConfig.java
@@ -1,0 +1,18 @@
+package com.thinktank.global.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.thinktank.global.auth.handler.AuthUserArgumentResolver;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+	@Override
+	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+		resolvers.add(new AuthUserArgumentResolver());
+	}
+}


### PR DESCRIPTION
## 📋 Checklist

- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. `feat: 유저 조회 기능 구현`)
- [ ] 🏷️ 라벨, 프로젝트는 등록했나요?
- [ ] 🧹 코드 스멜은 해결했나요?

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #28 

## 👩‍💻 공유 포인트 및 논의 사항
변경사항: 
- @Auth 어노테이션을 생성하여, 컨트롤러에서 현재 인증된 사용자 정보를 쉽게 접근할 수 있도록 하였습니다.
- findUserDetails에서 @Auth 어노테이션을 적용하여, 요청을 수행한 사용자 정보를 직접 조회할 수 있도록 했습니다.

구현 세부 사항: 
- @Auth 어노테이션은 파라미터로 @AuthenticationPrincipal을 사용하여 현재 인증된 사용자의 정보를 가져오도록 설계했습니다.
- 인증되지 않은 사용자의 경우 `null`을 반환하도록 하여, 인증된 사용자만이 특정 기능을 사용할 수 있도록 제한했습니다.
```java
@GetMapping("/users")
public ResponseEntity<UserResDto> findUserDetails(@Auth AuthUser authUser) {
    return ResponseEntity.ok(userService.findUserDetails(authUser));
}
```
- 위 코드와 같이 @Auth AuthUser authUser를 파라미터로 지정하여, 현재 인증된 사용자 정보를 AuthUser로 직접 사용할 수 있습니다.