### PR TITLE
feat: 마이페이지 사용자 정보 수정 기능 구현

### DIFF
--- a/src/main/java/com/thinktank/api/controller/UserController.java
+++ b/src/main/java/com/thinktank/api/controller/UserController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.thinktank.api.dto.user.request.LoginReqDto;
 import com.thinktank.api.dto.user.request.SignUpDto;
-import com.thinktank.api.dto.user.request.UserReqDto;
+import com.thinktank.api.dto.user.request.UserDeleteDto;
 import com.thinktank.api.dto.user.response.LoginResDto;
 import com.thinktank.api.dto.user.response.UserResDto;
 import com.thinktank.api.entity.auth.AuthUser;
@@ -60,8 +60,8 @@ public class UserController {
 	}
 
 	@DeleteMapping
-	public ResponseEntity<String> removeUser(@Auth AuthUser authUser, UserReqDto userReqDto) {
-		userService.removeUser(authUser, userReqDto);
+	public ResponseEntity<String> removeUser(@Auth AuthUser authUser, UserDeleteDto userDeleteDto) {
+		userService.removeUser(authUser, userDeleteDto);
 		return ResponseEntity.ok("OK");
 	}
 }

--- a/src/main/java/com/thinktank/api/controller/UserProfileController.java
+++ b/src/main/java/com/thinktank/api/controller/UserProfileController.java
@@ -1,0 +1,42 @@
+package com.thinktank.api.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.thinktank.api.dto.profileImage.request.ProfileImageReqDto;
+import com.thinktank.api.dto.user.request.UserUpdateDto;
+import com.thinktank.api.entity.auth.AuthUser;
+import com.thinktank.api.service.UserProfileService;
+import com.thinktank.api.service.UserService;
+import com.thinktank.global.auth.annotation.Auth;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/mypage")
+public class UserProfileController {
+
+	private final UserProfileService userProfileService;
+	private final UserService userService;
+
+	@PutMapping("/users/image")
+	public ResponseEntity<String> saveOrUpdateProfileImage(
+		@Auth AuthUser authUser,
+		@RequestBody @Validated ProfileImageReqDto profileImageReqDto) {
+		userProfileService.saveOrUpdateProfileImage(authUser, profileImageReqDto);
+		return ResponseEntity.ok("OK");
+	}
+
+	@PutMapping("/users")
+	public ResponseEntity<String> updateUserNickname(
+		@Auth AuthUser authUser,
+		@RequestBody @Validated UserUpdateDto userUpdateDto) {
+		userService.updateUserNickname(authUser, userUpdateDto);
+		return ResponseEntity.ok("OK");
+	}
+}

--- a/src/main/java/com/thinktank/api/dto/profileImage/request/ProfileImageReqDto.java
+++ b/src/main/java/com/thinktank/api/dto/profileImage/request/ProfileImageReqDto.java
@@ -1,0 +1,11 @@
+package com.thinktank.api.dto.profileImage.request;
+
+import jakarta.validation.constraints.Pattern;
+
+public record ProfileImageReqDto(
+	String fileName,
+	@Pattern(regexp = "([^\\s]+(\\.(?i)(jpg|png|jpeg))$)", message = "[❎ ERROR] 확장자는 png, jpg, jpeg만 가능합니다.")
+	String fileUrl,
+	String originalFileName
+) {
+}

--- a/src/main/java/com/thinktank/api/dto/user/request/UserDeleteDto.java
+++ b/src/main/java/com/thinktank/api/dto/user/request/UserDeleteDto.java
@@ -2,7 +2,7 @@ package com.thinktank.api.dto.user.request;
 
 import jakarta.validation.constraints.NotBlank;
 
-public record UserReqDto(
+public record UserDeleteDto(
 	@NotBlank(message = "[❎ ERROR] 비밀번호를 입력해주세요.")
 	String password
 ) {

--- a/src/main/java/com/thinktank/api/dto/user/request/UserUpdateDto.java
+++ b/src/main/java/com/thinktank/api/dto/user/request/UserUpdateDto.java
@@ -1,0 +1,13 @@
+package com.thinktank.api.dto.user.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record UserUpdateDto(
+	@NotBlank(message = "[❎ ERROR] 닉네임을 입력해주세요.")
+	@Size(min = 2, max = 10, message = "[❎ ERROR] 닉네임은 2글자에서 10글자 사이여야 합니다.")
+	@Pattern(regexp = "^[A-Za-z\\d]+$", message = "[❎ ERROR] 닉네임은 영문과 숫자만 사용가능합니다.")
+	String nickname
+) {
+}

--- a/src/main/java/com/thinktank/api/entity/ProfileImage.java
+++ b/src/main/java/com/thinktank/api/entity/ProfileImage.java
@@ -1,5 +1,7 @@
 package com.thinktank.api.entity;
 
+import com.thinktank.api.dto.profileImage.request.ProfileImageReqDto;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -10,6 +12,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -35,4 +38,28 @@ public class ProfileImage {
 	@OneToOne(fetch = FetchType.LAZY, orphanRemoval = true)
 	@JoinColumn(name = "user_id")
 	private User user;
+
+	@Builder
+	public ProfileImage(String fileName, String fileUrl, String originalFileName, User user) {
+		this.fileName = fileName;
+		this.fileUrl = fileUrl;
+		this.originalFileName = originalFileName;
+		this.user = user;
+	}
+
+	public static ProfileImage createWithUser(User user) {
+		return ProfileImage.builder()
+			.fileName(null)
+			.fileUrl(null)
+			.originalFileName(null)
+			.user(user)
+			.build();
+	}
+
+	public void updateProfileImage(ProfileImageReqDto profileImageReqDto, User user) {
+		this.fileName = profileImageReqDto.fileName();
+		this.fileUrl = profileImageReqDto.fileUrl();
+		this.originalFileName = profileImageReqDto.originalFileName();
+		this.user = user;
+	}
 }

--- a/src/main/java/com/thinktank/api/entity/User.java
+++ b/src/main/java/com/thinktank/api/entity/User.java
@@ -77,4 +77,8 @@ public class User extends BaseTimeEntity {
 	public void updateRefreshToken(String refreshToken) {
 		this.refreshToken = refreshToken;
 	}
+
+	public void updateNickname(String nickname) {
+		this.nickname = nickname;
+	}
 }

--- a/src/main/java/com/thinktank/api/repository/ProfileImageRepository.java
+++ b/src/main/java/com/thinktank/api/repository/ProfileImageRepository.java
@@ -1,8 +1,12 @@
 package com.thinktank.api.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.thinktank.api.entity.ProfileImage;
 
 public interface ProfileImageRepository extends JpaRepository<ProfileImage, Long> {
+
+	Optional<ProfileImage> findByUserEmail(String email);
 }

--- a/src/main/java/com/thinktank/api/service/UserProfileService.java
+++ b/src/main/java/com/thinktank/api/service/UserProfileService.java
@@ -1,0 +1,41 @@
+package com.thinktank.api.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.thinktank.api.dto.profileImage.request.ProfileImageReqDto;
+import com.thinktank.api.entity.ProfileImage;
+import com.thinktank.api.entity.User;
+import com.thinktank.api.entity.auth.AuthUser;
+import com.thinktank.api.repository.ProfileImageRepository;
+import com.thinktank.api.repository.UserRepository;
+import com.thinktank.global.error.exception.NotFoundException;
+import com.thinktank.global.error.model.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserProfileService {
+
+	private final ProfileImageRepository profileImageRepository;
+	private final UserRepository userRepository;
+
+	@Transactional
+	public void saveOrUpdateProfileImage(AuthUser authUser, ProfileImageReqDto profileImageReqDto) {
+		final User user = userRepository.findByEmail(authUser.email())
+			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_NOT_USER_FOUND_EXCEPTION));
+
+		profileImageRepository.findByUserEmail(user.getEmail())
+			.ifPresentOrElse(
+				updateProfileImage -> updateProfileImage.updateProfileImage(profileImageReqDto, user),
+				() -> createProfileImage(user)
+			);
+	}
+
+	private void createProfileImage(User user) {
+		ProfileImage profileImage = ProfileImage.createWithUser(user);
+		profileImageRepository.save(profileImage);
+	}
+}

--- a/src/main/java/com/thinktank/api/service/UserService.java
+++ b/src/main/java/com/thinktank/api/service/UserService.java
@@ -5,7 +5,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.thinktank.api.dto.user.request.SignUpDto;
-import com.thinktank.api.dto.user.request.UserReqDto;
+import com.thinktank.api.dto.user.request.UserDeleteDto;
+import com.thinktank.api.dto.user.request.UserUpdateDto;
 import com.thinktank.api.dto.user.response.UserResDto;
 import com.thinktank.api.entity.User;
 import com.thinktank.api.entity.auth.AuthUser;
@@ -42,10 +43,19 @@ public class UserService {
 	}
 
 	@Transactional
-	public void removeUser(AuthUser authUser, UserReqDto userReqDto) {
+	public void updateUserNickname(AuthUser authUser, UserUpdateDto userUpdateDto) {
 		final User user = findByUserEmail(authUser.email());
 
-		validatePasswordEquality(user.getPassword(), userReqDto.password());
+		validateNicknameNotExists(userUpdateDto.nickname());
+
+		user.updateNickname(userUpdateDto.nickname());
+	}
+
+	@Transactional
+	public void removeUser(AuthUser authUser, UserDeleteDto userDeleteDto) {
+		final User user = findByUserEmail(authUser.email());
+
+		validatePasswordEquality(user.getPassword(), userDeleteDto.password());
 
 		userRepository.delete(user);
 	}

--- a/src/main/java/com/thinktank/global/config/SecurityConfig.java
+++ b/src/main/java/com/thinktank/global/config/SecurityConfig.java
@@ -48,7 +48,6 @@ public class SecurityConfig {
 
 	@Bean
 	public PasswordEncoder passwordEncoder() {
-
 		return new BCryptPasswordEncoder();
 	}
 
@@ -58,6 +57,8 @@ public class SecurityConfig {
 		httpSecurity.csrf(AbstractHttpConfigurer::disable)
 			.httpBasic(AbstractHttpConfigurer::disable)
 			.sessionManagement(session -> session.sessionCreationPolicy(STATELESS));
+
+		httpSecurity.cors(AbstractHttpConfigurer::disable);
 
 		httpSecurity.authorizeHttpRequests((auth) -> auth
 			.requestMatchers("/api/login", "/api/logout", "/api/signup").permitAll()

--- a/src/main/java/com/thinktank/global/config/WebConfig.java
+++ b/src/main/java/com/thinktank/global/config/WebConfig.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import com.thinktank.global.auth.handler.AuthUserArgumentResolver;
@@ -14,5 +15,14 @@ public class WebConfig implements WebMvcConfigurer {
 	@Override
 	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
 		resolvers.add(new AuthUserArgumentResolver());
+	}
+
+	@Override
+	public void addCorsMappings(CorsRegistry registry) {
+		registry.addMapping("/api/**")
+			.allowedOrigins("http://localhost:5173")
+			.allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+			.allowedHeaders("*")
+			.allowCredentials(true);
 	}
 }


### PR DESCRIPTION
## 📋 Checklist

- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. `feat: 유저 조회 기능 구현`)
- [ ] 🏷️ 라벨, 프로젝트는 등록했나요?
- [ ] 🧹 코드 스멜은 해결했나요?

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #36 

## 👩‍💻 공유 포인트 및 논의 사항
- 마이페이지 사용자 프로필 이미지 생성 및 업데이트 로직 구현했습니다.
- 마이페이지 사용자 닉네임 수정 로직 구현했습니다.
- 사용자 프로필 이미지 생성 시, fileUrl은 확장자가 png, jpg, jpeg만 가능하도록 했습니다.
- CORS 설정 비활성화했습니다.