### PR TITLE
feat: 로그인 없이 댓글 목록 조회하기

### DIFF
--- a/src/main/java/com/thinktank/api/service/CommentService.java
+++ b/src/main/java/com/thinktank/api/service/CommentService.java
@@ -51,9 +51,6 @@ public class CommentService {
 
 	@Transactional(readOnly = true)
 	public CommentsResponseDto getCommentsByPostId(Long postId, AuthUser authUser, int pageIndex, int pageSize) {
-		final User user = userRepository.findByEmail(authUser.email())
-			.orElseThrow(() -> new UnauthorizedException(ErrorCode.FAIL_UNAUTHORIZED_EXCEPTION));
-
 		Pageable pageable = PageRequest.of(pageIndex, pageSize);
 		Page<Comment> page = commentRepository.findByPostId(postId, pageable);
 
@@ -62,7 +59,7 @@ public class CommentService {
 				comment.getId(),
 				comment.getContent(),
 				comment.getCreatedAt().toString(),
-				comment.getUser().getEmail().equals(user.getEmail()),
+				(authUser == null) ? false : comment.getUser().getEmail().equals(authUser.email()),
 				new CommentUserResponseDto(comment.getUser().getNickname())
 			))
 			.collect(Collectors.toList());

--- a/src/main/java/com/thinktank/api/service/CommentService.java
+++ b/src/main/java/com/thinktank/api/service/CommentService.java
@@ -59,7 +59,7 @@ public class CommentService {
 				comment.getId(),
 				comment.getContent(),
 				comment.getCreatedAt().toString(),
-				(authUser == null) ? false : comment.getUser().getEmail().equals(authUser.email()),
+				authUser != null && comment.getUser().getEmail().equals(authUser.email()),
 				new CommentUserResponseDto(comment.getUser().getNickname())
 			))
 			.collect(Collectors.toList());

--- a/src/main/java/com/thinktank/global/config/SecurityConfig.java
+++ b/src/main/java/com/thinktank/global/config/SecurityConfig.java
@@ -47,7 +47,8 @@ public class SecurityConfig {
 			.requestMatchers(PathRequest.toStaticResources().atCommonLocations())
 			.requestMatchers("/h2-console/**")
 			.requestMatchers("/api/signup")
-			.requestMatchers("/api/login");
+			.requestMatchers("/api/login")
+			.requestMatchers("/api/posts/*/comments");
 	}
 
 	@Bean


### PR DESCRIPTION
## 📋 Checklist

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. `feat: 유저 조회 기능 구현`)
- [x] 🏷️ 라벨, 프로젝트는 등록했나요?
- [x] 🧹 코드 스멜은 해결했나요?

## 🧩 #82 <!-- 이슈 번호를 작성해주세요 -->

- close #82

## 👩‍💻 공유 포인트 및 논의 사항
- 로그인 후 댓글 목록 조회하던 기능을 로그인 없이도 댓글 목록 조회가 가능하도록 변경하였습니다.
- 프론트에서 급하게 요청이 와서, 창민님께 공유하고 리뷰 없이 머지 진행하였습니다.
