### PR TITLE
refactor: 로그인 한 사용자 정보 저장하도록 수정

### DIFF
--- a/src/main/java/com/thinktank/api/controller/PostController.java
+++ b/src/main/java/com/thinktank/api/controller/PostController.java
@@ -19,7 +19,6 @@ import com.thinktank.api.entity.auth.AuthUser;
 import com.thinktank.api.service.PostService;
 import com.thinktank.global.auth.annotation.Auth;
 
-import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -30,7 +29,8 @@ public class PostController {
 
 	@PostMapping
 	public ResponseEntity<String> createPost(@RequestBody @Validated PostCreateDto postCreateDto,
-		@Auth AuthUser authUser) {
+		@Auth AuthUser authUser
+	) {
 		postService.createPost(postCreateDto, authUser);
 		return ResponseEntity.ok("OK");
 	}
@@ -39,24 +39,24 @@ public class PostController {
 	public ResponseEntity<PagePostResponseDto> getAllPosts(
 		@RequestParam(defaultValue = "0") int page,
 		@RequestParam(defaultValue = "10") int size,
-		@RequestParam @Nullable Long userId
+		@Auth(required = false) AuthUser authUser
 	) {
-		PagePostResponseDto posts = postService.getAllPosts(page, size, userId);
-		return ResponseEntity.ok(posts);
+		return ResponseEntity.ok(postService.getAllPosts(page, size, authUser));
 	}
 
 	@GetMapping("/{post-id}")
 	public ResponseEntity<PostDetailResponseDto> getPostDetails(
 		@PathVariable("post-id") Long postId,
-		@RequestParam @Nullable Long userId) {
-		PostDetailResponseDto postDetailResponseDto = postService.getPostDetail(postId, userId);
-		return ResponseEntity.ok(postDetailResponseDto);
+		@Auth(required = false) AuthUser authUser
+	) {
+		return ResponseEntity.ok(postService.getPostDetail(postId, authUser));
 	}
 
 	@DeleteMapping
 	public ResponseEntity<String> deletePost(
 		@RequestBody @Validated PostDeleteDto postDeleteDto,
-		@Auth AuthUser authUser) {
+		@Auth AuthUser authUser
+	) {
 		postService.deletePost(postDeleteDto, authUser);
 		return ResponseEntity.ok("OK");
 	}

--- a/src/main/java/com/thinktank/api/controller/UserPostController.java
+++ b/src/main/java/com/thinktank/api/controller/UserPostController.java
@@ -7,7 +7,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.thinktank.api.dto.post.response.PagePostProfileResponseDto;
+import com.thinktank.api.entity.auth.AuthUser;
 import com.thinktank.api.service.UserPostService;
+import com.thinktank.global.auth.annotation.Auth;
 
 import lombok.RequiredArgsConstructor;
 
@@ -22,10 +24,10 @@ public class UserPostController {
 		@RequestParam(defaultValue = "0") int page,
 		@RequestParam(defaultValue = "10") int size,
 		@RequestParam String value,
-		@RequestParam String userNickname,
-		@RequestParam(required = false) Long loginUserId) {
-		PagePostProfileResponseDto profilePosts = userPostService.getProfilePosts(page, size, value, userNickname,
-			loginUserId);
+		@RequestParam String email,
+		@Auth AuthUser authUser) {
+		PagePostProfileResponseDto profilePosts = userPostService.getProfilePosts(page, size, value, email,
+			authUser);
 		return ResponseEntity.ok(profilePosts);
 	}
 }

--- a/src/main/java/com/thinktank/api/dto/post/request/PostCreateDto.java
+++ b/src/main/java/com/thinktank/api/dto/post/request/PostCreateDto.java
@@ -28,6 +28,6 @@ public record PostCreateDto(
 	List<CustomTestCase> testCases,
 
 	@NotBlank(message = "[❎ ERROR] 정답 코드는 필수 입력값입니다.")
-	String answer
+	String code
 ) {
 }

--- a/src/main/java/com/thinktank/api/entity/Post.java
+++ b/src/main/java/com/thinktank/api/entity/Post.java
@@ -56,8 +56,8 @@ public class Post extends BaseTimeEntity {
 	@ColumnDefault("0")
 	private int answerCount = 0;
 
-	@Column(name = "answer", nullable = false)
-	private String answer;
+	@Column(name = "code", nullable = false)
+	private String code;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")
@@ -70,7 +70,7 @@ public class Post extends BaseTimeEntity {
 		Language language,
 		String content,
 		String condition,
-		String answer,
+		String code,
 		User user
 	) {
 		this.title = title;
@@ -78,7 +78,7 @@ public class Post extends BaseTimeEntity {
 		this.language = language;
 		this.content = content;
 		this.condition = condition;
-		this.answer = answer;
+		this.code = code;
 		this.user = user;
 	}
 
@@ -90,7 +90,7 @@ public class Post extends BaseTimeEntity {
 			.language(Language.fromValue(postCreateDto.language()))
 			.content(postCreateDto.content())
 			.condition(postCreateDto.condition())
-			.answer(postCreateDto.answer())
+			.code(postCreateDto.code())
 			.user(user)
 			.build();
 	}

--- a/src/main/java/com/thinktank/api/repository/ProfileImageRepository.java
+++ b/src/main/java/com/thinktank/api/repository/ProfileImageRepository.java
@@ -9,4 +9,9 @@ import com.thinktank.api.entity.ProfileImage;
 public interface ProfileImageRepository extends JpaRepository<ProfileImage, Long> {
 
 	Optional<ProfileImage> findByUserEmail(String email);
+
+	default String findByUserId(Long userId) {
+		ProfileImage profileImage = findById(userId).orElse(null);
+		return profileImage != null ? profileImage.getProfileImage() : null;
+	}
 }

--- a/src/main/java/com/thinktank/api/repository/UserLikeRepository.java
+++ b/src/main/java/com/thinktank/api/repository/UserLikeRepository.java
@@ -14,7 +14,7 @@ public interface UserLikeRepository extends JpaRepository<UserLike, Long> {
 
 	boolean existsByLikeIdAndUserId(Long id, Long userId);
 
-	UserLike findByUserIdAndLikePostId(Long userId, Long postId);
+	UserLike findByUserEmailAndLikePostId(String email, Long postId);
 
 	List<UserLike> findByLikePostId(Long postId);
 

--- a/src/main/java/com/thinktank/api/repository/UserRepository.java
+++ b/src/main/java/com/thinktank/api/repository/UserRepository.java
@@ -21,4 +21,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	@Query("SELECT u.id FROM User u WHERE u.nickname = :nickname")
 	Long findUserIdByNickname(@Param("nickname") String userNickname);
 
+	Long findUserIdByEmail(String email);
 }

--- a/src/main/java/com/thinktank/api/service/PostService.java
+++ b/src/main/java/com/thinktank/api/service/PostService.java
@@ -8,7 +8,6 @@ import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +22,7 @@ import com.thinktank.api.dto.user.response.SimpleUserResDto;
 import com.thinktank.api.entity.Category;
 import com.thinktank.api.entity.Language;
 import com.thinktank.api.entity.Post;
+import com.thinktank.api.entity.ProfileImage;
 import com.thinktank.api.entity.TestCase;
 import com.thinktank.api.entity.User;
 import com.thinktank.api.entity.UserLike;
@@ -30,6 +30,7 @@ import com.thinktank.api.entity.auth.AuthUser;
 import com.thinktank.api.repository.CommentRepository;
 import com.thinktank.api.repository.LikeRepository;
 import com.thinktank.api.repository.PostRepository;
+import com.thinktank.api.repository.ProfileImageRepository;
 import com.thinktank.api.repository.TestCaseRepository;
 import com.thinktank.api.repository.UserCodeRepository;
 import com.thinktank.api.repository.UserLikeRepository;
@@ -56,11 +57,11 @@ public class PostService {
 	private final TestCaseRepository testCaseRepository;
 	private final UserLikeRepository userLikeRepository;
 	private final UserCodeRepository userCodeRepository;
+	private final ProfileImageRepository profileImageRepository;
 	private final UserLikeService userLikeService;
 
 	public void createPost(PostCreateDto postCreateDto, AuthUser authUser) {
-		final User user = userRepository.findByEmail(authUser.email())
-			.orElseThrow(() -> new UnauthorizedException(ErrorCode.FAIL_LOGIN_REQUIRED));
+		final User user = findUserByEmail(authUser.email());
 
 		validateCategory(postCreateDto.category());
 		validateLanguage(postCreateDto.language());
@@ -68,7 +69,7 @@ public class PostService {
 		final Post post = Post.create(postCreateDto, user);
 		final List<CustomTestCase> customTestCases = postCreateDto.testCases();
 
-		validateJudge(customTestCases, postCreateDto.answer(), postCreateDto.language());
+		validateJudge(customTestCases, postCreateDto.code(), postCreateDto.language());
 
 		final List<TestCase> testCases = customTestCases.stream()
 			.map(customTestCase -> TestCase.createTestCase(customTestCase, post))
@@ -79,42 +80,36 @@ public class PostService {
 	}
 
 	@Transactional(readOnly = true)
-	public PagePostResponseDto getAllPosts(int page, int size, Long userId) {
-		Optional<User> optionalUser = userId != null ? userRepository.findById(userId) : Optional.empty();
-		Pageable pageable = PageRequest.of(page, size);
-		Page<Post> postPage = postRepository.findAll(pageable);
-		String profileImage = null;
-		List<PostsResponseDto> posts = postPage.getContent().stream()
-			.map(post -> toPost(post, profileImage, optionalUser.map(User::getId).orElse(null)))
-			.toList();
-		PageInfo pageInfo = new PageInfo(
-			postPage.getNumber(),
-			postPage.isLast()
-		);
+	public PagePostResponseDto getAllPosts(int page, int size, AuthUser authUser) {
+		Page<Post> postPage = postRepository.findAll(PageRequest.of(page, size));
 
-		return new PagePostResponseDto(posts, pageInfo);
+		List<PostsResponseDto> postsResponseDtoList = convertPostListToDtoList(postPage.getContent(), authUser);
+
+		PageInfo pageInfo = new PageInfo(postPage.getNumber(), postPage.isLast());
+
+		return new PagePostResponseDto(postsResponseDtoList, pageInfo);
 	}
 
 	@Transactional(readOnly = true)
-	public PostDetailResponseDto getPostDetail(Long postId, Long userId) {
-		Optional<User> optionalUser = userId != null ? userRepository.findById(userId) : Optional.empty();
+	public PostDetailResponseDto getPostDetail(Long postId, AuthUser authUser) {
+		Optional<AuthUser> optionalAuthUser = Optional.ofNullable(authUser);
 
-		Post post = postRepository.findById(postId)
+		String userEmail = optionalAuthUser.map(AuthUser::email).orElse(null);
+
+		final Post post = postRepository.findById(postId)
 			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_POST_NOT_FOUND));
+
 		List<CustomTestCase> testCases = testCaseRepository.findByPostId(postId);
 
-		return mapToPostDetailResponseDto(post, testCases, optionalUser.map(User::getId).orElse(null));
+		return mapToPostDetailResponseDto(post, testCases, userEmail);
 	}
 
 	public void deletePost(PostDeleteDto postDeleteDto, AuthUser authUser) {
-		final User user = userRepository.findByEmail(authUser.email())
-			.orElseThrow(() -> new UnauthorizedException(ErrorCode.FAIL_LOGIN_REQUIRED));
-		Post post = postRepository.findById(postDeleteDto.postId())
-			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_POST_NOT_FOUND));
+		final User user = findUserByEmail(authUser.email());
+		final Post post = findPostById(postDeleteDto.postId());
 
-		if (!Objects.equals(user.getId(), post.getUser().getId())) {
-			throw new BadRequestException(ErrorCode.FAIL_POST_DELETION_FORBIDDEN);
-		}
+		validateUserOwnership(user, post);
+
 		userCodeRepository.deleteByPostId(postDeleteDto.postId());
 		commentRepository.deleteByPostId(postDeleteDto.postId());
 		testCaseRepository.deleteByPostId(postDeleteDto.postId());
@@ -124,35 +119,41 @@ public class PostService {
 		postRepository.delete(post);
 	}
 
-	private PostDetailResponseDto mapToPostDetailResponseDto(Post post, List<CustomTestCase> testCases, Long userId) {
-		int commentCount = commentRepository.countCommentsByPost(post);
-		int likeCount = likeRepository.findLikeCountByPost(post);
-		int answerCount = userCodeRepository.countUserCodeByPost(post);
-		boolean likeType = isPostLikedByUser(userId, post);
-		return new PostDetailResponseDto(
-			post.getId(),
-			post.getTitle(),
-			post.getCategory().toString(),
-			post.getCreatedAt(),
-			post.getContent(),
-			testCases,
-			post.getCondition(),
-			post.getUser().getId().equals(userId),
-			likeCount,
-			commentCount,
-			answerCount,
-			post.getLanguage().toString(),
-			likeType,
-			post.getAnswer()
-		);
+	private User findUserByEmail(String email) {
+		return userRepository.findByEmail(email)
+			.orElseThrow(() -> new UnauthorizedException(ErrorCode.FAIL_LOGIN_REQUIRED));
 	}
 
-	private PostsResponseDto toPost(Post post, String profileImage, Long userId) {
-		SimpleUserResDto user = toUser(post.getUser(), profileImage);
-		int commentCount = commentRepository.countCommentsByPost(post);
-		int likeCount = likeRepository.findLikeCountByPost(post);
-		int answerCount = userCodeRepository.countUserCodeByPost(post);
-		boolean likeType = isPostLikedByUser(userId, post);
+	private Post findPostById(Long postId) {
+		return postRepository.findById(postId)
+			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_POST_NOT_FOUND));
+	}
+
+	private List<PostsResponseDto> convertPostListToDtoList(List<Post> posts, AuthUser authUser) {
+		if (authUser == null) {
+			return posts.stream()
+				.map(post -> convertPostToResponseDto(post, null))
+				.toList();
+		}
+
+		return posts.stream()
+			.map(post -> convertPostToResponseDto(post, authUser.email()))
+			.toList();
+	}
+
+	private PostsResponseDto convertPostToResponseDto(Post post, String userEmail) {
+		final int commentCount = commentRepository.countCommentsByPost(post);
+		final int likeCount = likeRepository.findLikeCountByPost(post);
+		final int codeCount = userCodeRepository.countUserCodeByPost(post);
+		final boolean likeType = userLikeService.isPostLikedByUser(userEmail, post.getId());
+
+		SimpleUserResDto simpleUserResDto = createSimpleUserResDto(post);
+
+		return createPostsResponseDto(post, commentCount, likeCount, codeCount, likeType, simpleUserResDto);
+	}
+
+	private PostsResponseDto createPostsResponseDto(Post post, int commentCount, int likeCount, int codeCount,
+		boolean likeType, SimpleUserResDto simpleUserResDto) {
 
 		return new PostsResponseDto(
 			post.getId(),
@@ -163,21 +164,44 @@ public class PostService {
 			post.getContent(),
 			commentCount,
 			likeCount,
-			answerCount,
+			codeCount,
 			likeType,
-			user
+			simpleUserResDto);
+	}
+
+	private PostDetailResponseDto mapToPostDetailResponseDto(Post post, List<CustomTestCase> testCases,
+		String userEmail) {
+		int commentCount = commentRepository.countCommentsByPost(post);
+		int likeCount = likeRepository.findLikeCountByPost(post);
+		int codeCount = userCodeRepository.countUserCodeByPost(post);
+		boolean likeType = userLikeService.isPostLikedByUser(userEmail, post.getId());
+		boolean isOwner = post.getUser().getEmail().equals(userEmail);
+
+		return new PostDetailResponseDto(
+			post.getId(),
+			post.getTitle(),
+			post.getCategory().toString(),
+			post.getCreatedAt(),
+			post.getContent(),
+			testCases,
+			post.getCondition(),
+			isOwner,
+			likeCount,
+			commentCount,
+			codeCount,
+			post.getLanguage().toString(),
+			likeType,
+			post.getCode()
 		);
 	}
 
-	private SimpleUserResDto toUser(User user, String profileImage) {
-		return new SimpleUserResDto(
-			user.getNickname(),
-			profileImage
-		);
-	}
+	private SimpleUserResDto createSimpleUserResDto(Post post) {
+		final User user = findUserByEmail(post.getUser().getEmail());
 
-	private boolean isPostLikedByUser(Long userId, Post post) {
-		return userLikeService.isPostLikedByUser(userId, post.getId());
+		final ProfileImage profileImage = profileImageRepository.findByUserEmail(user.getEmail())
+			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_IMAGE_NOT_FOUND));
+
+		return new SimpleUserResDto(user.getNickname(), profileImage.getProfileImage());
 	}
 
 	private void validateCategory(String category) {
@@ -192,6 +216,12 @@ public class PostService {
 		}
 	}
 
+	private void validateUserOwnership(User user, Post post) {
+		if (!Objects.equals(user.getId(), post.getUser().getId())) {
+			throw new BadRequestException(ErrorCode.FAIL_POST_DELETION_FORBIDDEN);
+		}
+	}
+
 	private void validateJudge(List<CustomTestCase> testCases, String code, String language) {
 		final JudgeUtil judgeService;
 
@@ -200,7 +230,7 @@ public class PostService {
 		} else if (language.equals("javascript")) {
 			judgeService = new JavaScriptJudge();
 		} else {
-			throw new BadRequestException(ErrorCode.FAIL_POST_NOT_FOUND);
+			throw new NotFoundException(ErrorCode.FAIL_POST_NOT_FOUND);
 		}
 
 		judgeService.executeCode(testCases, code);

--- a/src/main/java/com/thinktank/api/service/UserLikeService.java
+++ b/src/main/java/com/thinktank/api/service/UserLikeService.java
@@ -12,10 +12,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class UserLikeService {
+
 	private final UserLikeRepository userLikeRepository;
 
-	public boolean isPostLikedByUser(Long userId, Long postId) {
-		UserLike userLike = userLikeRepository.findByUserIdAndLikePostId(userId, postId);
+	public boolean isPostLikedByUser(String email, Long postId) {
+		UserLike userLike = userLikeRepository.findByUserEmailAndLikePostId(email, postId);
 		return userLike != null && userLike.isCheck();
 	}
 }

--- a/src/main/java/com/thinktank/api/service/auth/JwtProviderService.java
+++ b/src/main/java/com/thinktank/api/service/auth/JwtProviderService.java
@@ -102,7 +102,6 @@ public class JwtProviderService {
 			log.warn("====== TOKEN EXPIRED ======");
 		} catch (IllegalArgumentException e) {
 			log.warn("====== EMPTIED TOKEN ======");
-			throw new NotFoundException(ErrorCode.FAIL_TOKEN_NOT_FOUND);
 		} catch (Exception e) {
 			log.warn("====== INVALID TOKEN ======");
 			throw new UnauthorizedException(ErrorCode.FAIL_INVALID_TOKEN);

--- a/src/main/java/com/thinktank/global/auth/handler/AuthUserArgumentResolver.java
+++ b/src/main/java/com/thinktank/global/auth/handler/AuthUserArgumentResolver.java
@@ -12,12 +12,15 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 import com.thinktank.api.entity.auth.AuthUser;
+import com.thinktank.global.auth.AuthorizationThreadLocal;
 import com.thinktank.global.auth.annotation.Auth;
 import com.thinktank.global.error.exception.UnauthorizedException;
 import com.thinktank.global.error.model.ErrorCode;
 
 import jakarta.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
 
 	@Override
@@ -44,10 +47,14 @@ public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
 	}
 
 	private AuthUser getAuthUser(boolean isAuthRequired) throws UnauthorizedException {
-		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		AuthUser authUser = AuthorizationThreadLocal.getAuthUser();
+		if (authUser != null) {
+			return authUser;
+		}
 
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 		if (authentication != null && !(authentication instanceof AnonymousAuthenticationToken)) {
-			return (AuthUser)authentication.getPrincipal();
+			return (AuthUser) authentication.getPrincipal();
 		}
 
 		if (isAuthRequired) {

--- a/src/main/java/com/thinktank/global/config/SecurityConfig.java
+++ b/src/main/java/com/thinktank/global/config/SecurityConfig.java
@@ -50,7 +50,6 @@ public class SecurityConfig {
 			.requestMatchers("/api/signup")
 			.requestMatchers("/api/login")
 			.requestMatchers("/api/posts/*/comments")
-			.requestMatchers(HttpMethod.GET, "/api/posts/**")
 			.requestMatchers("/api/users/profile");
 	}
 


### PR DESCRIPTION
## 📋 Checklist

- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. `feat: 유저 조회 기능 구현`)
- [ ] 🏷️ 라벨, 프로젝트는 등록했나요?
- [ ] 🧹 코드 스멜은 해결했나요?

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #115 

## 👩‍💻 공유 포인트 및 논의 사항
- 게시글 목록 조회 시 로그인을 한 사용자의 정보가 저장되지 않는 문제를 해결했습니다.
- 게시글 서비스 로직 리팩토링을 진행했습니다.