### PR TITLE
refactor: 변수명 통일, 타인 프로필 조회 시 페이징 처리 수정, 전반적인 코드 스타일 수정, 카테고리 추가

### DIFF
--- a/src/main/java/com/thinktank/api/dto/post/response/PostDetailResponseDto.java
+++ b/src/main/java/com/thinktank/api/dto/post/response/PostDetailResponseDto.java
@@ -7,6 +7,7 @@ import com.thinktank.api.dto.testcase.custom.CustomTestCase;
 
 public record PostDetailResponseDto(
 	Long postId,
+	Long postNumber,
 	String title,
 	String category,
 	LocalDateTime createdAt,
@@ -16,9 +17,9 @@ public record PostDetailResponseDto(
 	boolean isAuthor,
 	int likeCount,
 	int commentCount,
-	int answerCount,
+	int codeCount,
 	String language,
 	boolean likeType,
-	String answer
+	String code
 ) {
 }

--- a/src/main/java/com/thinktank/api/dto/post/response/PostProfileResponseDto.java
+++ b/src/main/java/com/thinktank/api/dto/post/response/PostProfileResponseDto.java
@@ -1,14 +1,18 @@
 package com.thinktank.api.dto.post.response;
 
+import java.time.LocalDateTime;
+
 public record PostProfileResponseDto(
 	Long postId,
 	Long postNumber,
 	String title,
 	String category,
+	LocalDateTime createdAt,
+	String content,
 	boolean likeType,
 	int commentCount,
 	int likeCount,
-	int answerCount
+	int codeCount
 ) implements PostResponseDto {
 	@Override
 	public Long getPostId() {
@@ -25,4 +29,3 @@ public record PostProfileResponseDto(
 		return title;
 	}
 }
-

--- a/src/main/java/com/thinktank/api/dto/post/response/PostSolvedResponseDto.java
+++ b/src/main/java/com/thinktank/api/dto/post/response/PostSolvedResponseDto.java
@@ -22,4 +22,3 @@ public record PostSolvedResponseDto(
 		return title;
 	}
 }
-

--- a/src/main/java/com/thinktank/api/dto/post/response/PostsResponseDto.java
+++ b/src/main/java/com/thinktank/api/dto/post/response/PostsResponseDto.java
@@ -13,7 +13,7 @@ public record PostsResponseDto(
 	String content,
 	int commentCount,
 	int likeCount,
-	int answerCount,
+	int codeCount,
 	boolean likeType,
 	SimpleUserResDto user
 ) {

--- a/src/main/java/com/thinktank/api/dto/user/response/SimpleUserResDto.java
+++ b/src/main/java/com/thinktank/api/dto/user/response/SimpleUserResDto.java
@@ -1,7 +1,8 @@
 package com.thinktank.api.dto.user.response;
 
 public record SimpleUserResDto(
-	String nickName,
+	String email,
+	String nickname,
 	String profileImage
 ) {
 }

--- a/src/main/java/com/thinktank/api/entity/Category.java
+++ b/src/main/java/com/thinktank/api/entity/Category.java
@@ -6,7 +6,28 @@ import java.util.Map;
 
 public enum Category {
 	DFS("깊이우선탐색", "dfs"),
-	BFS("너비우선탐색", "bfs");
+	BFS("너비우선탐색", "bfs"),
+	SelectionSort("선택 정렬", "SelectionSort"),
+	QuickSort("퀵 정렬", "QuickSort"),
+	MergeSort("병합 정렬", "MergeSort"),
+	HeapSort("힙 정렬", "HeapSort"),
+	RadixSort("기수 정렬", "RadixSort"),
+	BinarySearch("이진 탐색", "BinarySearch"),
+	LinearSearch("선형 탐색", "LinearSearch"),
+	FibonacciSequence("피보나치 수열", "FibonacciSequence"),
+	KnapsackProblem("배낭 문제", "KnapsackProblem"),
+	LongestCommonSubsequence("최장 공통 부분 수열", "LongestCommonSubsequence"),
+	LongestIncreasingSubsequence("최장 증가 부분 수열", "LongestIncreasingSubsequence"),
+	CoinChangeProblem("동전 교환 문제", "CoinChangeProblem"),
+	NQueensProblem("N-퀸 문제", "NQueensProblem"),
+	HamiltonianPaths("해밀턴 경로", "HamiltonianPaths"),
+	PermutationsGeneration("순열 생성", "PermutationsGeneration"),
+	EuclideanAlgorithm("유클리드 알고리즘", "EuclideanAlgorithm"),
+	PrimeNumberChecking("소수 판별", "PrimeNumberChecking"),
+	MatrixOperations("행렬 연산", "MatrixOperations"),
+	ConvexHull("볼록 껍질", "ConvexHull"),
+	LineSegmentIntersection("선분 교차", "LineSegmentIntersection"),
+	ClosestPairofPoints("최근접 점 쌍", "ClosestPairofPoints");
 
 	private final String name;
 	private final String value;

--- a/src/main/java/com/thinktank/api/entity/Language.java
+++ b/src/main/java/com/thinktank/api/entity/Language.java
@@ -5,8 +5,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 public enum Language {
-	JAVA("자바", "java"),
-	JAVASCRIPT("자바스크립트", "javascript");
+	Java("자바", "java"),
+	Javascript("자바스크립트", "javascript");
 
 	private final String name;
 	private final String value;

--- a/src/main/java/com/thinktank/api/entity/Post.java
+++ b/src/main/java/com/thinktank/api/entity/Post.java
@@ -52,9 +52,9 @@ public class Post extends BaseTimeEntity {
 	@ColumnDefault("0")
 	private int commentCount = 0;
 
-	@Column(name = "answer_count", nullable = false)
+	@Column(name = "code_count", nullable = false)
 	@ColumnDefault("0")
-	private int answerCount = 0;
+	private int codeCount = 0;
 
 	@Column(name = "code", nullable = false)
 	private String code;

--- a/src/main/java/com/thinktank/api/repository/PostRepository.java
+++ b/src/main/java/com/thinktank/api/repository/PostRepository.java
@@ -1,12 +1,12 @@
 package com.thinktank.api.repository;
 
-import java.util.List;
-
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.thinktank.api.entity.Post;
 import com.thinktank.api.entity.User;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
-	List<Post> findByUser(User user);
+	Page<Post> findByUser(User user, Pageable pageable);
 }

--- a/src/main/java/com/thinktank/api/repository/UserCodeRepository.java
+++ b/src/main/java/com/thinktank/api/repository/UserCodeRepository.java
@@ -1,7 +1,7 @@
 package com.thinktank.api.repository;
 
-import java.util.List;
-
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -20,5 +20,5 @@ public interface UserCodeRepository extends JpaRepository<UserCode, Long> {
 
 	UserCode findByPostId(Long postId);
 
-	List<UserCode> findByUser(User user);
+	Page<UserCode> findByUser(User user, Pageable pageable);
 }

--- a/src/main/java/com/thinktank/api/repository/UserLikeRepository.java
+++ b/src/main/java/com/thinktank/api/repository/UserLikeRepository.java
@@ -3,6 +3,8 @@ package com.thinktank.api.repository;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.thinktank.api.entity.User;
@@ -18,5 +20,5 @@ public interface UserLikeRepository extends JpaRepository<UserLike, Long> {
 
 	List<UserLike> findByLikePostId(Long postId);
 
-	List<UserLike> findByUserAndIsCheckTrue(User user);
+	Page<UserLike> findByUserAndIsCheckTrue(User user, Pageable pageable);
 }

--- a/src/main/java/com/thinktank/api/repository/UserRepository.java
+++ b/src/main/java/com/thinktank/api/repository/UserRepository.java
@@ -3,8 +3,6 @@ package com.thinktank.api.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.thinktank.api.entity.User;
@@ -17,9 +15,4 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	boolean existsByEmail(String email);
 
 	boolean existsByNickname(String nickname);
-
-	@Query("SELECT u.id FROM User u WHERE u.nickname = :nickname")
-	Long findUserIdByNickname(@Param("nickname") String userNickname);
-
-	Long findUserIdByEmail(String email);
 }

--- a/src/main/java/com/thinktank/api/service/PostService.java
+++ b/src/main/java/com/thinktank/api/service/PostService.java
@@ -101,7 +101,7 @@ public class PostService {
 
 		List<CustomTestCase> testCases = testCaseRepository.findByPostId(postId);
 
-		return mapToPostDetailResponseDto(post, testCases, userEmail);
+		return convertPostToDetailResponseDto(post, testCases, userEmail);
 	}
 
 	public void deletePost(PostDeleteDto postDeleteDto, AuthUser authUser) {
@@ -156,20 +156,11 @@ public class PostService {
 		boolean likeType, SimpleUserResDto simpleUserResDto) {
 
 		return new PostsResponseDto(
-			post.getId(),
-			post.getId() + THOUSAND,
-			post.getTitle(),
-			post.getCategory().toString(),
-			post.getCreatedAt(),
-			post.getContent(),
-			commentCount,
-			likeCount,
-			codeCount,
-			likeType,
-			simpleUserResDto);
+			post.getId(), post.getId() + THOUSAND, post.getTitle(), post.getCategory().toString(),
+			post.getCreatedAt(), post.getContent(), commentCount, likeCount, codeCount, likeType, simpleUserResDto);
 	}
 
-	private PostDetailResponseDto mapToPostDetailResponseDto(Post post, List<CustomTestCase> testCases,
+	private PostDetailResponseDto convertPostToDetailResponseDto(Post post, List<CustomTestCase> testCases,
 		String userEmail) {
 		int commentCount = commentRepository.countCommentsByPost(post);
 		int likeCount = likeRepository.findLikeCountByPost(post);
@@ -177,22 +168,17 @@ public class PostService {
 		boolean likeType = userLikeService.isPostLikedByUser(userEmail, post.getId());
 		boolean isOwner = post.getUser().getEmail().equals(userEmail);
 
-		return new PostDetailResponseDto(
-			post.getId(),
-			post.getTitle(),
-			post.getCategory().toString(),
-			post.getCreatedAt(),
-			post.getContent(),
-			testCases,
-			post.getCondition(),
-			isOwner,
-			likeCount,
-			commentCount,
-			codeCount,
-			post.getLanguage().toString(),
-			likeType,
-			post.getCode()
+		return createPostDetailResponseDto(post, testCases, commentCount, likeCount, codeCount, likeType, isOwner);
+	}
+
+	private PostDetailResponseDto createPostDetailResponseDto(Post post, List<CustomTestCase> testCases,
+		int commentCount, int likeCount, int codeCount, boolean likeType, boolean isOwner) {
+		return new PostDetailResponseDto(post.getId(),
+			post.getId() + THOUSAND, post.getTitle(), post.getCategory().toString(), post.getCreatedAt(),
+			post.getContent(), testCases, post.getCondition(), isOwner, likeCount, commentCount, codeCount,
+			post.getLanguage().toString(), likeType, post.getCode()
 		);
+
 	}
 
 	private SimpleUserResDto createSimpleUserResDto(Post post) {
@@ -201,7 +187,7 @@ public class PostService {
 		final ProfileImage profileImage = profileImageRepository.findByUserEmail(user.getEmail())
 			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_IMAGE_NOT_FOUND));
 
-		return new SimpleUserResDto(user.getNickname(), profileImage.getProfileImage());
+		return new SimpleUserResDto(user.getEmail(), user.getNickname(), profileImage.getProfileImage());
 	}
 
 	private void validateCategory(String category) {


### PR DESCRIPTION
## 📋 Checklist

- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. `feat: 유저 조회 기능 구현`)
- [ ] 🏷️ 라벨, 프로젝트는 등록했나요?
- [ ] 🧹 코드 스멜은 해결했나요?

## 🧩 이슈 번호 #101 

- close #101 

## 👩‍💻 공유 포인트 및 논의 사항
post의 answer를 모두 code로 변경(변수명 통일)
기존에 profileImage를 무조건 null처리했던 부분을 user의 profileImage로 받아서 오도록 수정
category에 bfs,dfs이외의 카테고리 추가
userNickname으로 받아오던것( 타인 프로필 조회 시) → 유저의 email 로 받도록 수정
로그인/ 비로그인 사용자 조회 authUser로 받도록 수정
타인 프로필 조회시 페이징 처리 수정
nickName->nickname(변수명 통일)

모두 수정 완료 하였습니다.
